### PR TITLE
adds support for variable highlighting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the "typo3-fluid" extension will be documented in this fi
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [0.2.0]
+
+- Added syntax highlighting for Fluid comments
+
 ## [0.1.2]
 
 - Fixed compatibility issue with Cursor AI by decreasing required VS Code version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the "typo3-fluid" extension will be documented in this fi
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [0.2.0]
+
+- Added support for variables without or inside tags
+- Added support for inline variables (depends on theme highlighting features)
+
 ## [0.1.2]
 
 - Fixed compatibility issue with Cursor AI by decreasing required VS Code version

--- a/package.json
+++ b/package.json
@@ -2,8 +2,11 @@
   "name": "vscode-typo3-fluid",
   "displayName": "Typo3 Fluid Syntax Highlighting",
   "description": "Syntax highlighting for TYPO3 Fluid",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "publisher": "leon-wbr",
+  "contributors": [
+    "rp-feflo"
+  ],
   "icon": "icons/typo3.png",
   "engines": {
     "vscode": "^1.89.0"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-typo3-fluid",
   "displayName": "Typo3 Fluid Syntax Highlighting",
   "description": "Syntax highlighting for TYPO3 Fluid",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "publisher": "leon-wbr",
   "contributors": [
     "rp-feflo"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-typo3-fluid",
   "displayName": "Typo3 Fluid Syntax Highlighting",
   "description": "Syntax highlighting for TYPO3 Fluid",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "publisher": "leon-wbr",
   "icon": "icons/typo3.png",
   "engines": {

--- a/syntaxes/fluid.tmLanguage.json
+++ b/syntaxes/fluid.tmLanguage.json
@@ -5,6 +5,29 @@
   "fileTypes": ["html"],
   "patterns": [
     {
+      "include": "#fluid-variables"
+    },
+    {
+      "include": "#html-tags-with-fluid"
+    },
+    {
+      "name": "comment.block.html",
+      "begin": "(<f:comment(?:\\s[^>]*)?>)",
+      "end": "(</f:comment>)",
+      "beginCaptures": {
+        "1": { "name": "punctuation.definition.comment.html" }
+      },
+      "endCaptures": {
+        "1": { "name": "punctuation.definition.comment.html" }
+      },
+      "patterns": [
+        {
+          "match": "[^<]+|<[^/]|<(?=[^f])",
+          "name": "comment.block.html"
+        }
+      ]
+    },
+    {
       "include": "text.html.derivative"
     },
     {
@@ -12,11 +35,53 @@
     }
   ],
   "repository": {
-    "fluid-tags": {
+    "fluid-variables": {
+      "name": "variable.block.html",
+      "match": "\\{[^}]*\\}",
+      "captures": {
+        "0": { "name": "variable.block.html" }
+      }
+    },
+    "html-tags-with-fluid": {
+      "begin": "(<)([a-zA-Z0-9:-]+)",
+      "end": "(>)",
+      "beginCaptures": {
+        "1": { "name": "punctuation.definition.tag.begin.html" },
+        "2": { "name": "entity.name.tag.html" }
+      },
+      "endCaptures": {
+        "1": { "name": "punctuation.definition.tag.end.html" }
+      },
       "patterns": [
         {
-          "name": "entity.name.tag.fluid",
-          "match": "<f:[a-zA-Z]+"
+          "include": "#fluid-variables"
+        },
+        {
+          "match": "\\s+([a-zA-Z0-9:-]+)(=)",
+          "captures": {
+            "1": { "name": "entity.other.attribute-name.html" },
+            "2": { "name": "punctuation.separator.key-value.html" }
+          }
+        },
+        {
+          "begin": "\"",
+          "end": "\"",
+          "name": "string.quoted.double.html",
+          "patterns": [
+            {
+              "include": "#fluid-variables"
+            }
+          ]
+        },
+        {
+          "begin": "'",
+          "end": "'",
+          "name": "string.quoted.single.html",
+          "patterns": [
+            {
+              "include": "#fluid-variables"
+            }
+          ]
         }
       ]
     }

--- a/syntaxes/fluid.tmLanguage.json
+++ b/syntaxes/fluid.tmLanguage.json
@@ -5,20 +5,27 @@
   "fileTypes": ["html"],
   "patterns": [
     {
+      "name": "comment.block.html",
+      "begin": "(<f:comment(?:\\s[^>]*)?>)",
+      "end": "(</f:comment>)",
+      "beginCaptures": {
+        "1": { "name": "punctuation.definition.comment.html" }
+      },
+      "endCaptures": {
+        "1": { "name": "punctuation.definition.comment.html" }
+      },
+      "patterns": [
+        {
+          "match": "[^<]+|<[^/]|<(?=[^f])",
+          "name": "comment.block.html"
+        }
+      ]
+    },
+    {
       "include": "text.html.derivative"
     },
     {
       "include": "#fluid-tags"
     }
-  ],
-  "repository": {
-    "fluid-tags": {
-      "patterns": [
-        {
-          "name": "entity.name.tag.fluid",
-          "match": "<f:[a-zA-Z]+"
-        }
-      ]
-    }
-  }
+  ]
 }


### PR DESCRIPTION
Adding support for variables inside tags or with inline notation. The inline notation depends on the VS Code theme.

The Dark (Visual Studio - not Dark+ or Dark Modern) does not support `variable.block.html` for inline notation:
![Bildschirmfoto 2025-09-08 um 08 53 53](https://github.com/user-attachments/assets/3e5a3944-b631-458b-86ea-c1e1413939c9)

The GithHub Dark Default theme delivers:
![Bildschirmfoto 2025-09-08 um 08 54 15](https://github.com/user-attachments/assets/8b1a9598-2407-461c-a078-c28ae4d2aeb7)
